### PR TITLE
Declare SubAssembly input pipes.

### DIFF
--- a/src/main/java/bixo/pipes/FetchPipe.java
+++ b/src/main/java/bixo/pipes/FetchPipe.java
@@ -229,7 +229,7 @@ public class FetchPipe extends SubAssembly {
     
     public FetchPipe(Pipe urlProvider, BaseScoreGenerator scorer, BaseFetcher fetcher, BaseFetcher robotsFetcher, BaseRobotsParser parser,
                     BaseFetchJobPolicy fetchJobPolicy, int numReducers) {
-        
+        super(urlProvider);
         Pipe robotsPipe = new Each(urlProvider, new GroupFunction(new GroupByDomain()));
         robotsPipe = new GroupBy("Grouping URLs by IP/delay", robotsPipe, GroupedUrlDatum.getGroupingField());
         robotsPipe = new Every(robotsPipe, new FilterAndScoreByUrlAndRobots(robotsFetcher, parser, scorer), Fields.RESULTS);

--- a/src/main/java/bixo/pipes/ParsePipe.java
+++ b/src/main/java/bixo/pipes/ParsePipe.java
@@ -99,6 +99,7 @@ public class ParsePipe extends SubAssembly {
     }
     
     public ParsePipe(Pipe fetcherPipe, BaseParser parser) {
+        super(fetcherPipe);
         Pipe parsePipe = new Pipe(PARSE_PIPE_NAME, fetcherPipe);
 
         ParseFunction parserFunction = new ParseFunction(parser);


### PR DESCRIPTION
Cascading 2.2 requires the input pipes for SubAssemblies to be declared.  This change wasn't mentioned in the release notes, but Cascading complains every time the assemblies are used, and they added the requirement in the javadocs and reference manual.  
